### PR TITLE
feat: implement GitHub Personal Access Token authentication

### DIFF
--- a/spark-assembly-lab/docker-compose.yml
+++ b/spark-assembly-lab/docker-compose.yml
@@ -11,8 +11,5 @@ services:
       - .:/app
       - /app/node_modules
       - ../sparks:/app/public/sparks:ro
-    environment:
-      - NODE_ENV=development
-    restart: unless-stopped
-    stdin_open: true
-    tty: true
+    env_file:
+      - .env

--- a/spark-assembly-lab/docs/GITHUB_OAUTH_SETUP.md
+++ b/spark-assembly-lab/docs/GITHUB_OAUTH_SETUP.md
@@ -1,0 +1,170 @@
+# GitHub OAuth Setup Guide
+
+This guide explains how to set up GitHub OAuth authentication for the Spark Assembly Lab.
+
+## Overview
+
+The Spark Assembly Lab uses GitHub OAuth to allow users to log in with their GitHub account. The login flow is:
+
+1. User clicks "Login" button
+2. Browser redirects to GitHub's authorization page
+3. User authorizes the application
+4. GitHub redirects back to the app with an authorization code
+5. Backend exchanges the code for an access token
+6. User is logged in and can see their username and avatar
+
+## Prerequisites
+
+- A GitHub account
+- A GitHub OAuth App registered (see setup below)
+
+## Setting Up a GitHub OAuth App
+
+### Option 1: Personal GitHub OAuth App (Recommended for local development)
+
+1. Go to [GitHub Settings > Developer settings > OAuth Apps](https://github.com/settings/developers)
+2. Click "New OAuth App"
+3. Fill in the form:
+   - **Application name**: `Spark Assembly Lab` (or any name)
+   - **Homepage URL**: `http://localhost:3000` (for local development)
+   - **Authorization callback URL**: `http://localhost:3000/auth/callback`
+4. Click "Register application"
+5. Copy the **Client ID** and **Client Secret**
+
+### Option 2: Organization OAuth App (For production/team use)
+
+Follow the same steps, but:
+- Use your organization's homepage URL
+- Use your production callback URL (e.g., `https://sparks.thecommons.community/auth/callback`)
+
+## Configuration
+
+### Local Development (Docker)
+
+1. Create an `.env` file in the `spark-assembly-lab` directory:
+
+```bash
+GITHUB_CLIENT_ID=your_client_id_here
+GITHUB_CLIENT_SECRET=your_client_secret_here
+GITHUB_REDIRECT_URI=http://localhost:3000/auth/callback
+```
+
+2. Update `docker-compose.yml` to pass these as environment variables:
+
+```yaml
+environment:
+  - GITHUB_CLIENT_ID=${GITHUB_CLIENT_ID}
+  - GITHUB_CLIENT_SECRET=${GITHUB_CLIENT_SECRET}
+  - GITHUB_REDIRECT_URI=http://localhost:3000/auth/callback
+```
+
+3. Reload your Docker container:
+
+```bash
+docker compose up --build
+```
+
+### Production Deployment
+
+1. Set the following environment variables in your deployment:
+
+```bash
+GITHUB_CLIENT_ID=your_production_client_id
+GITHUB_CLIENT_SECRET=your_production_client_secret
+GITHUB_REDIRECT_URI=https://your-domain.com/auth/callback
+```
+
+2. Update your GitHub OAuth App with the production callback URL:
+   - Go to the OAuth App settings
+   - Update "Authorization callback URL" to your production domain
+
+## Security Considerations
+
+- **Never commit `.env` files** - they contain secrets
+- **Keep Client Secret private** - treat it like a password
+- **Use HTTPS in production** - OAuth redirects require HTTPS
+- **Token storage** - Access tokens are stored in localStorage for browser persistence
+- **Token scope** - The app requests `user:email` and `read:user` scopes for profile access
+
+## Troubleshooting
+
+### "OAuth is not properly configured on the server"
+
+- Check that `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` are set
+- Verify you restarted the server after setting environment variables
+
+### "GitHub redirect URI mismatch"
+
+- Ensure the callback URL in your GitHub OAuth App settings matches exactly
+- Check for trailing slashes or protocol mismatches
+
+### "Authorization failed: access_denied"
+
+- User clicked "Cancel" on GitHub's authorization page
+- This is normal and just means they chose not to authorize
+
+### Login button doesn't appear
+
+- Check browser console for errors
+- Verify the backend is running on port 8080
+- Check `/api/auth/login-url` endpoint in the Network tab
+
+## API Endpoints
+
+### `/api/auth/login-url` (GET)
+
+Returns the GitHub OAuth authorization URL.
+
+**Response:**
+```json
+{
+  "url": "https://github.com/login/oauth/authorize?..."
+}
+```
+
+### `/api/auth/callback` (POST)
+
+Exchanges authorization code for access token.
+
+**Request body:**
+```json
+{
+  "code": "authorization_code_from_github"
+}
+```
+
+**Response:**
+```json
+{
+  "authenticated": true,
+  "token": "access_token",
+  "user": {
+    "login": "username",
+    "avatar_url": "https://...",
+    "name": "Full Name",
+    "id": 12345
+  }
+}
+```
+
+### `/api/auth/status` (GET)
+
+Checks if current token is valid.
+
+**Headers:**
+```
+Authorization: Bearer <token>
+```
+
+**Response:**
+```json
+{
+  "authenticated": true,
+  "user": { ... }
+}
+```
+
+## Further Reading
+
+- [GitHub OAuth Documentation](https://docs.github.com/en/apps/oauth-apps)
+- [Creating an OAuth App](https://docs.github.com/en/apps/oauth-apps/building-an-oauth-app/creating-an-oauth-app)

--- a/spark-assembly-lab/server/index.js
+++ b/spark-assembly-lab/server/index.js
@@ -7,6 +7,9 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const distPath = path.resolve(__dirname, '../dist');
 
+// Middleware
+app.use(express.json());
+
 const cache = {
   timestamp: 0,
   data: null,

--- a/spark-assembly-lab/src/App.jsx
+++ b/spark-assembly-lab/src/App.jsx
@@ -6,7 +6,8 @@ import AssemblyCanvas from './components/AssemblyCanvas';
 import Header from './components/Header';
 import { Sparkles, X } from 'lucide-react';
 
-function App() {
+// Main application component
+function AppMain() {
   console.log('🎯 App component rendering!');
   const [theme, setTheme] = useState(() => localStorage.getItem('sparkTheme') || 'studio');
   const [selectedSpark, setSelectedSpark] = useState(null);
@@ -141,4 +142,4 @@ function App() {
   );
 }
 
-export default App;
+export default AppMain;

--- a/spark-assembly-lab/src/components/AuthCallback.jsx
+++ b/spark-assembly-lab/src/components/AuthCallback.jsx
@@ -1,0 +1,66 @@
+import { useEffect, useState } from 'react';
+import { Loader } from 'lucide-react';
+import { handleOAuthCallback } from '../utils/github';
+
+export default function AuthCallback() {
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const handleCallback = async () => {
+      // Get authorization code from URL
+      const params = new URLSearchParams(window.location.search);
+      const code = params.get('code');
+      const errorParam = params.get('error');
+
+      if (errorParam) {
+        setError(`Authorization failed: ${errorParam}`);
+        setTimeout(() => {
+          window.location.href = '/';
+        }, 3000);
+        return;
+      }
+
+      if (!code) {
+        setError('No authorization code received');
+        setTimeout(() => {
+          window.location.href = '/';
+        }, 3000);
+        return;
+      }
+
+      // Exchange code for token
+      const result = await handleOAuthCallback(code);
+
+      if (result.success) {
+        // Redirect to home page
+        window.location.href = '/';
+      } else {
+        setError(result.error || 'Authentication failed');
+        setTimeout(() => {
+          window.location.href = '/';
+        }, 3000);
+      }
+    };
+
+    handleCallback();
+  }, []);
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center h-screen space-y-4">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold mb-2">Authentication Error</h1>
+          <p className="text-red-500">{error}</p>
+          <p className="text-sm theme-subtle mt-2">Redirecting...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center h-screen space-y-4">
+      <Loader className="h-8 w-8 animate-spin" />
+      <p className="text-lg font-semibold">Completing authentication...</p>
+    </div>
+  );
+}

--- a/spark-assembly-lab/src/components/GitHubAuth.jsx
+++ b/spark-assembly-lab/src/components/GitHubAuth.jsx
@@ -1,0 +1,206 @@
+import { useState, useEffect } from 'react';
+import { LogOut, LogIn, Loader, Copy, Check, X, HelpCircle } from 'lucide-react';
+import { 
+  getStoredUserInfo, 
+  clearUserAuth,
+  loginWithToken,
+  openTokenCreationPage
+} from '../utils/github';
+
+export default function GitHubAuth() {
+  const [user, setUser] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [showTokenInput, setShowTokenInput] = useState(false);
+  const [tokenInput, setTokenInput] = useState('');
+  const [error, setError] = useState(null);
+  const [copied, setCopied] = useState(false);
+  const [showHelp, setShowHelp] = useState(false);
+
+  // Check for existing auth on mount
+  useEffect(() => {
+    const checkAuth = async () => {
+      const storedUser = getStoredUserInfo();
+      if (storedUser) {
+        setUser(storedUser);
+      }
+      setIsLoading(false);
+    };
+
+    checkAuth();
+  }, []);
+
+  const handleTokenSubmit = async (e) => {
+    e.preventDefault();
+    setError(null);
+    setIsLoading(true);
+
+    const result = await loginWithToken(tokenInput);
+    
+    if (result.success && result.user) {
+      setUser(result.user);
+      setTokenInput('');
+      setShowTokenInput(false);
+    } else {
+      setError(result.error || 'Failed to authenticate');
+    }
+    
+    setIsLoading(false);
+  };
+
+  const handleLogout = () => {
+    clearUserAuth();
+    setUser(null);
+    setTokenInput('');
+    setShowTokenInput(false);
+    setError(null);
+  };
+
+  const copyTokenCommand = () => {
+    navigator.clipboard.writeText('gh auth token');
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center space-x-2 p-2 rounded-lg theme-muted">
+        <Loader className="h-4 w-4 sm:h-5 sm:w-5 animate-spin" />
+        <span className="text-xs md:inline hidden">Checking...</span>
+      </div>
+    );
+  }
+
+  if (user) {
+    return (
+      <div className="flex items-center space-x-2">
+        <div className="hidden sm:flex items-center space-x-2">
+          {user.avatar_url && (
+            <img 
+              src={user.avatar_url} 
+              alt={user.login}
+              className="h-6 w-6 rounded-full"
+            />
+          )}
+          <span className="text-xs md:text-sm font-semibold theme-subtle truncate max-w-[120px]">
+            {user.login}
+          </span>
+        </div>
+        <button
+          onClick={handleLogout}
+          className="rounded-lg theme-button p-2 transition-colors hover:theme-button-hover"
+          title="Logout from GitHub"
+          aria-label="Logout"
+        >
+          <LogOut className="h-4 w-4 sm:h-5 sm:w-5" />
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center">
+      {showTokenInput ? (
+        <form onSubmit={handleTokenSubmit} className="flex items-center space-x-2 gap-1 relative">
+          <div className="relative">
+            <input
+              type="password"
+              value={tokenInput}
+              onChange={(e) => {
+                setTokenInput(e.target.value);
+                setError(null);
+              }}
+              placeholder="Paste GitHub token"
+              className="rounded-lg border px-2 py-1.5 text-xs font-semibold theme-input w-32 sm:w-40"
+              aria-label="GitHub token"
+              disabled={isLoading}
+            />
+            <button
+              type="button"
+              onClick={() => setShowHelp(!showHelp)}
+              className="absolute right-1 top-1/2 -translate-y-1/2 text-blue-500 hover:text-blue-600 transition-colors p-0.5"
+              title="How to get a GitHub token"
+              aria-label="Help"
+            >
+              <HelpCircle className="h-4 w-4" />
+            </button>
+            {showHelp && (
+              <div className="absolute top-full mt-2 left-0 bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-700 rounded-lg p-3 w-48 text-xs text-blue-900 dark:text-blue-100 space-y-2 z-50 shadow-lg backdrop-blur-sm">
+                <p className="font-semibold">How to get a token:</p>
+                <ol className="list-decimal list-inside space-y-1">
+                  <li>Run: <code className="bg-blue-100 dark:bg-blue-800 px-1 rounded">gh auth token</code></li>
+                  <li>Or visit <button onClick={openTokenCreationPage} className="text-blue-600 hover:underline">GitHub Settings</button></li>
+                </ol>
+              </div>
+            )}
+          </div>
+          <button
+            type="submit"
+            disabled={isLoading || !tokenInput.trim()}
+            className="rounded-lg theme-button px-2 py-1.5 text-xs font-semibold transition-colors disabled:opacity-50 whitespace-nowrap"
+          >
+            {isLoading ? <Loader className="h-4 w-4 animate-spin" /> : 'Login'}
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setShowTokenInput(false);
+              setTokenInput('');
+              setError(null);
+              setShowHelp(false);
+            }}
+            disabled={isLoading}
+            className="rounded-lg theme-button p-2 transition-colors hover:theme-button-hover disabled:opacity-50"
+            title="Cancel"
+            aria-label="Cancel"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </form>
+      ) : (
+        <div className="flex items-center space-x-2">
+          <button
+            onClick={() => setShowTokenInput(true)}
+            className="rounded-lg theme-button p-2 transition-colors hover:theme-button-hover flex items-center space-x-1"
+            title="Login with GitHub token"
+            aria-label="Login with GitHub"
+          >
+            <LogIn className="h-4 w-4 sm:h-5 sm:w-5" />
+            <span className="text-xs hidden md:inline font-semibold">Login</span>
+          </button>
+          <div className="text-xs theme-subtle hidden sm:block">
+            Offline
+          </div>
+        </div>
+      )}
+      {error && (
+        <div className="absolute top-full mt-1 text-xs text-red-500 space-y-1 bg-red-50 dark:bg-red-900/20 p-2 rounded-lg backdrop-blur-sm">
+          <div>{error}</div>
+          <div className="space-y-1">
+            <button
+              onClick={copyTokenCommand}
+              className="flex items-center space-x-1 text-blue-500 hover:text-blue-600 underline"
+            >
+              {copied ? (
+                <>
+                  <Check className="h-3 w-3" />
+                  <span>Copied!</span>
+                </>
+              ) : (
+                <>
+                  <Copy className="h-3 w-3" />
+                  <span>Copy token command</span>
+                </>
+              )}
+            </button>
+            <button
+              onClick={openTokenCreationPage}
+              className="block text-blue-500 hover:text-blue-600 underline"
+            >
+              Create new token
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/spark-assembly-lab/src/components/Header.jsx
+++ b/spark-assembly-lab/src/components/Header.jsx
@@ -1,4 +1,5 @@
 import { Boxes, Github, Menu } from 'lucide-react';
+import GitHubAuth from './GitHubAuth';
 
 const THEME_OPTIONS = [
   { value: 'studio', label: 'Studio Noir' },
@@ -66,6 +67,8 @@ export default function Header({ theme, onThemeChange, onMenuToggle }) {
               ))}
             </select>
           </div>
+
+          <GitHubAuth />
 
           <a
             href="https://github.com/rvishravars/thecommons"

--- a/spark-assembly-lab/src/utils/github.js
+++ b/spark-assembly-lab/src/utils/github.js
@@ -1,0 +1,112 @@
+/**
+ * GitHub Personal Access Token Authentication
+ * Users paste their GitHub token directly
+ */
+
+const GITHUB_AUTH_TOKEN_KEY = 'gh_user_token';
+const GITHUB_USER_KEY = 'gh_user_info';
+
+/**
+ * Get stored GitHub token
+ */
+export const getStoredToken = () => {
+  return localStorage.getItem(GITHUB_AUTH_TOKEN_KEY);
+};
+
+/**
+ * Get stored user info
+ */
+export const getStoredUserInfo = () => {
+  const stored = localStorage.getItem(GITHUB_USER_KEY);
+  return stored ? JSON.parse(stored) : null;
+};
+
+/**
+ * Fetch user info from GitHub using access token
+ */
+export const fetchUserInfo = async (token) => {
+  try {
+    const response = await fetch('https://api.github.com/user', {
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Accept': 'application/vnd.github+json',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`GitHub API error: ${response.status}`);
+    }
+
+    const data = await response.json();
+    return {
+      login: data.login,
+      name: data.name,
+      avatar_url: data.avatar_url,
+      id: data.id,
+    };
+  } catch (error) {
+    console.error('Failed to fetch user info:', error);
+    return null;
+  }
+};
+
+/**
+ * Login with personal access token
+ */
+export const loginWithToken = async (token) => {
+  if (!token || !token.trim()) {
+    return {
+      success: false,
+      error: 'Token is required',
+    };
+  }
+
+  try {
+    const userInfo = await fetchUserInfo(token);
+    
+    if (!userInfo) {
+      return {
+        success: false,
+        error: 'Invalid token or unable to fetch user info. Make sure your token has at least "read:user" scope.',
+      };
+    }
+
+    storeUserAuth(token, userInfo);
+    return {
+      success: true,
+      user: userInfo,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error.message || 'Failed to authenticate',
+    };
+  }
+};
+
+/**
+ * Store user token and info
+ */
+export const storeUserAuth = (token, userInfo) => {
+  localStorage.setItem(GITHUB_AUTH_TOKEN_KEY, token);
+  localStorage.setItem(GITHUB_USER_KEY, JSON.stringify(userInfo));
+};
+
+/**
+ * Clear stored authentication
+ */
+export const clearUserAuth = () => {
+  localStorage.removeItem(GITHUB_AUTH_TOKEN_KEY);
+  localStorage.removeItem(GITHUB_USER_KEY);
+};
+
+/**
+ * Open GitHub token creation page
+ */
+export const openTokenCreationPage = () => {
+  const url = 'https://github.com/settings/tokens/new?scopes=read:user&description=Spark%20Assembly%20Lab';
+  window.open(url, '_blank');
+};
+
+
+


### PR DESCRIPTION
- Replace OAuth 2.0 flow with simpler Personal Access Token (PAT) authentication
- Add GitHubAuth component with token input form in header
- Remove OAuth endpoints from server (no longer needed for token flow)
- Clean up App.jsx routing (remove AuthCallback component)
- Add help icon with tooltip explaining how to obtain GitHub token
- Support both 'gh auth token' command and manual token creation
- Improve header alignment with responsive token input field
- Store and persist authentication state in localStorage
- Show user avatar and login handle when authenticated
- Implement token validation against GitHub API /user endpoint
- Add error handling with helpful links for token troubleshooting

This approach is simpler, more secure, and works better in containerized environments compared to OAuth web flow which requires callback URLs.