### PR TITLE
docs: update scribe CLI status and CS terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ New to the Commons? Here is how you earn your seat at the table by adding mass t
 2.  **Phase 2: Designer (+15 CS):** Use your **Design**. Take a hunch and give it a shape. Define the **Novel Core** using the `!SHAPE` template.
 3.  **Phase 3: Builder (+25 CS):** Use your **Logic**. Write the code or technical specs to turn a design into a functional brick using `!BUILD`.
 
+> **🚧 Coming Soon:** Automated merit tracking and CS (Contribution Score) point system. [Track progress →](https://github.com/rvishravars/thecommons/issues/2)
+
 
 ### Visual Tour & Demo
 
@@ -51,6 +53,8 @@ The Commons is assisted by an AI Scribe that ensures every new brick follows the
 * **`!SHAPE`**: Validates a blueprint and checks for "Prior Art" (Novelty Audit).
 * **`!BUILD`**: Runs a stability check to ensure your logic doesn't break existing bricks.
 * **`!VOTE_VETO`**: A community safety-valve to halt structural changes.
+
+> **🚧 Coming Soon:** Pure CLI-based interface for AI Scribe commands. Currently, the Scribe operates programmatically through the web interface.
 
 ---
 

--- a/spark-assembly-lab/scribe/logic/stability_audit.py
+++ b/spark-assembly-lab/scribe/logic/stability_audit.py
@@ -311,67 +311,71 @@ class StabilityAuditor:
         return "\n".join(lines)
 
 
-def main():
-    """CLI entry point for the stability auditor."""
-    import argparse
+# CLI INTERFACE - RESERVED FOR LATER
+# The AI scribe is not invoked via commands currently.
+# This functionality is preserved for future use.
 
-    parser = argparse.ArgumentParser(
-        description="Stability Audit for TheCommons Sparks"
-    )
-    parser.add_argument("--file", type=Path, help="Specific Spark file to audit")
-    parser.add_argument("--dir", type=Path, default=Path("sparks"), help="Directory containing Sparks")
-    parser.add_argument("--json", action="store_true", help="Output as JSON")
-    args = parser.parse_args()
+# def main():
+#     """CLI entry point for the stability auditor."""
+#     import argparse
+# 
+#     parser = argparse.ArgumentParser(
+#         description="Stability Audit for TheCommons Sparks"
+#     )
+#     parser.add_argument("--file", type=Path, help="Specific Spark file to audit")
+#     parser.add_argument("--dir", type=Path, default=Path("sparks"), help="Directory containing Sparks")
+#     parser.add_argument("--json", action="store_true", help="Output as JSON")
+# #     args = parser.parse_args()
+# 
+#     auditor = StabilityAuditor()
+# 
+#     # Collect files to audit
+#     files_to_audit = []
+#     if args.file:
+#         files_to_audit = [args.file]
+#     elif args.dir.exists():
+#         files_to_audit = sorted(args.dir.glob("*.spark.md"))
+# 
+#     if not files_to_audit:
+#         logger.warning(f"⚠️  No Spark files found in {args.dir}")
+#         return
+# 
+#     # Run audits
+#     all_valid = True
+#     reports = []
+# 
+#     for filepath in files_to_audit:
+#         report = auditor.audit_spark(filepath)
+#         if report:
+#             reports.append(report)
+#             if not report.is_valid:
+#                 all_valid = False
+# 
+#             if not args.json:
+#                 print(auditor.format_report(report))
+# 
+#     # JSON output
+#     if args.json:
+#         import json
+# 
+#         json_reports = []
+#         for report in reports:
+#             json_reports.append({
+#                 "filepath": report.filepath,
+#                 "is_valid": report.is_valid,
+#                 "completion_level": report.completion_level,
+#                 "novelty_score": report.novelty_score,
+#                 "critical_flaws": report.critical_flaws,
+#                 "warnings": report.warnings,
+#                 "recommendations": report.recommendations
+#             })
+# 
+#         print(json.dumps(json_reports, indent=2))
+# 
+#     # Exit code
+#     import sys
+#     sys.exit(0 if all_valid else 1)
 
-    auditor = StabilityAuditor()
 
-    # Collect files to audit
-    files_to_audit = []
-    if args.file:
-        files_to_audit = [args.file]
-    elif args.dir.exists():
-        files_to_audit = sorted(args.dir.glob("*.spark.md"))
-
-    if not files_to_audit:
-        logger.warning(f"⚠️  No Spark files found in {args.dir}")
-        return
-
-    # Run audits
-    all_valid = True
-    reports = []
-
-    for filepath in files_to_audit:
-        report = auditor.audit_spark(filepath)
-        if report:
-            reports.append(report)
-            if not report.is_valid:
-                all_valid = False
-
-            if not args.json:
-                print(auditor.format_report(report))
-
-    # JSON output
-    if args.json:
-        import json
-
-        json_reports = []
-        for report in reports:
-            json_reports.append({
-                "filepath": report.filepath,
-                "is_valid": report.is_valid,
-                "completion_level": report.completion_level,
-                "novelty_score": report.novelty_score,
-                "critical_flaws": report.critical_flaws,
-                "warnings": report.warnings,
-                "recommendations": report.recommendations
-            })
-
-        print(json.dumps(json_reports, indent=2))
-
-    # Exit code
-    import sys
-    sys.exit(0 if all_valid else 1)
-
-
-if __name__ == "__main__":
-    main()
+# if __name__ == "__main__":
+#     main()

--- a/spark-assembly-lab/scribe/missions.py
+++ b/spark-assembly-lab/scribe/missions.py
@@ -49,7 +49,7 @@ class MeritEntry:
     """Merit distribution entry."""
     handle: str
     role: str
-    reward: str  # e.g., "+5 CS", "+15 CS", "+25 CS"
+    reward: str  # e.g., "+5 CS", "+15 CS", "+25 CS" (CS = Contribution Score)
 
 
 class Mission1DataParser:
@@ -369,7 +369,7 @@ class Mission3GovernanceAdvisory:
     @staticmethod
     def _calculate_merit(spark_data: Dict[str, Any], audit_status: AuditStatus) -> List[Dict[str, str]]:
         """
-        Calculate merit (CS) distribution based on contributions.
+        Calculate merit (CS = Contribution Score) distribution based on contributions.
         
         Args:
             spark_data: Parsed spark data
@@ -489,16 +489,20 @@ def evaluate_spark_mission(content: str) -> Dict[str, Any]:
     return output
 
 
-if __name__ == "__main__":
-    # Example usage
-    import sys
-    
-    if len(sys.argv) < 2:
-        print("Usage: python missions.py <spark_file.md>")
-        sys.exit(1)
-    
-    with open(sys.argv[1], 'r') as f:
-        content = f.read()
-    
-    result = evaluate_spark_mission(content)
-    print(json.dumps(result, indent=2))
+# CLI INTERFACE - RESERVED FOR LATER
+# The AI scribe is not invoked via commands currently.
+# This functionality is preserved for future use.
+
+# if __name__ == "__main__":
+#     # Example usage
+#     import sys
+#     
+#     if len(sys.argv) < 2:
+#         print("Usage: python missions.py <spark_file.md>")
+#         sys.exit(1)
+#     
+#     with open(sys.argv[1], 'r') as f:
+#         content = f.read()
+#     
+#     result = evaluate_spark_mission(content)
+#     print(json.dumps(result, indent=2))

--- a/spark-assembly-lab/scribe/scribe_brain.py
+++ b/spark-assembly-lab/scribe/scribe_brain.py
@@ -482,74 +482,78 @@ class ScribeBrain:
         return mission_output
 
 
-def main():
-    """Main entry point for the Scribe Brain."""
-    import argparse
-    
-    parser = argparse.ArgumentParser(description="Scribe v2.0 Brain - Glass Box AI Agent")
-    parser.add_argument("--demo", action="store_true", help="Run in demo mode (no inference)")
-    parser.add_argument("--eval-file", type=str, help="Spark file to evaluate")
-    parser.add_argument("--phase", choices=["hunch", "shape"], default="hunch", help="Evaluation phase")
-    parser.add_argument("--missions", action="store_true", help="Run Scribe-Architect missions on a full Spark")
-    args = parser.parse_args()
+# CLI INTERFACE - RESERVED FOR LATER
+# The AI scribe is not invoked via commands currently.
+# This functionality is preserved for future use.
 
-    logger.info("🧠 Initializing Scribe v2.0 Brain...")
-
-    if args.demo:
-        logger.info("📊 Running in DEMO MODE (no inference required)")
-        demo_mode()
-        return
-
-    brain = ScribeBrain()
-    logger.info(f"Hardware selected: {brain.hardware.value}")
-
-    try:
-        if args.missions:
-            if not args.eval_file:
-                logger.error("--missions requires --eval-file")
-                sys.exit(1)
-
-            with open(args.eval_file, "r") as f:
-                spark_content = f.read()
-
-            logger.info("📥 Running Scribe-Architect missions...")
-            mission_result = brain.evaluate_spark_missions(spark_content)
-            logger.info("\n" + json.dumps(mission_result, indent=2))
-            return
-
-        if args.eval_file:
-            with open(args.eval_file, "r") as f:
-                spark_content = f.read()
-
-            logger.info(f"📥 Evaluating {args.phase.upper()} from file...")
-            result = brain.evaluate_spark(EvaluationPhase(args.phase), spark_content)
-        else:
-            # Example: Evaluate a sample hunch
-            sample_hunch = """
-            I notice that our Spark files don't have consistent date fields. 
-            It's hard to track when a blueprint was created vs. when it was approved.
-            This makes it difficult to analyze the velocity of the Commons.
-            """
-
-            logger.info("📥 Evaluating sample HUNCH...")
-            result = brain.evaluate_spark(EvaluationPhase.HUNCH, sample_hunch)
-
-        if result:
-            logger.info("\n" + brain.output_result(result))
-        else:
-            logger.error("Evaluation failed")
-            logger.info("\n💡 HELP:")
-            logger.info("   1. Download model: python spark-assembly-lab/scribe/models/downloader.py --download")
-            logger.info("   2. Or use demo mode: python spark-assembly-lab/scribe/scribe_brain.py --demo")
-            logger.info("   3. Or set Groq API: export GROQ_API_KEY='your-key'")
-            sys.exit(1)
-    except Exception as e:
-        logger.error(f"Fatal error during evaluation: {e}")
-        logger.info("\n💡 HELP:")
-        logger.info("   • Run demo mode: python spark-assembly-lab/scribe/scribe_brain.py --demo")
-        logger.info("   • Install model: python spark-assembly-lab/scribe/models/downloader.py --download")
-        logger.info("   • Check dependencies: pip install -r spark-assembly-lab/scribe/requirements.txt")
-        sys.exit(1)
+# def main():
+#     """Main entry point for the Scribe Brain."""
+#     import argparse
+#     
+#     parser = argparse.ArgumentParser(description="Scribe v2.0 Brain - Glass Box AI Agent")
+#     parser.add_argument("--demo", action="store_true", help="Run in demo mode (no inference)")
+#     parser.add_argument("--eval-file", type=str, help="Spark file to evaluate")
+#     parser.add_argument("--phase", choices=["hunch", "shape"], default="hunch", help="Evaluation phase")
+#     parser.add_argument("--missions", action="store_true", help="Run Scribe-Architect missions on a full Spark")
+# #     args = parser.parse_args()
+# 
+#     logger.info("🧠 Initializing Scribe v2.0 Brain...")
+# 
+#     if args.demo:
+#         logger.info("📊 Running in DEMO MODE (no inference required)")
+#         demo_mode()
+#         return
+# 
+#     brain = ScribeBrain()
+#     logger.info(f"Hardware selected: {brain.hardware.value}")
+# 
+#     try:
+#         if args.missions:
+#             if not args.eval_file:
+#                 logger.error("--missions requires --eval-file")
+#                 sys.exit(1)
+# 
+#             with open(args.eval_file, "r") as f:
+#                 spark_content = f.read()
+# 
+#             logger.info("📥 Running Scribe-Architect missions...")
+#             mission_result = brain.evaluate_spark_missions(spark_content)
+#             logger.info("\n" + json.dumps(mission_result, indent=2))
+#             return
+# 
+#         if args.eval_file:
+#             with open(args.eval_file, "r") as f:
+#                 spark_content = f.read()
+# 
+#             logger.info(f"📥 Evaluating {args.phase.upper()} from file...")
+#             result = brain.evaluate_spark(EvaluationPhase(args.phase), spark_content)
+#         else:
+#             # Example: Evaluate a sample hunch
+#             sample_hunch = """
+#             I notice that our Spark files don't have consistent date fields. 
+#             It's hard to track when a blueprint was created vs. when it was approved.
+#             This makes it difficult to analyze the velocity of the Commons.
+#             """
+# 
+#             logger.info("📥 Evaluating sample HUNCH...")
+#             result = brain.evaluate_spark(EvaluationPhase.HUNCH, sample_hunch)
+# 
+#         if result:
+#             logger.info("\n" + brain.output_result(result))
+#         else:
+#             logger.error("Evaluation failed")
+#             logger.info("\n💡 HELP:")
+#             logger.info("   1. Download model: python spark-assembly-lab/scribe/models/downloader.py --download")
+#             logger.info("   2. Or use demo mode: python spark-assembly-lab/scribe/scribe_brain.py --demo")
+#             logger.info("   3. Or set Groq API: export GROQ_API_KEY='your-key'")
+#             sys.exit(1)
+#     except Exception as e:
+#         logger.error(f"Fatal error during evaluation: {e}")
+#         logger.info("\n💡 HELP:")
+#         logger.info("   • Run demo mode: python spark-assembly-lab/scribe/scribe_brain.py --demo")
+#         logger.info("   • Install model: python spark-assembly-lab/scribe/models/downloader.py --download")
+#         logger.info("   • Check dependencies: pip install -r spark-assembly-lab/scribe/requirements.txt")
+#         sys.exit(1)
 
 
 def demo_mode():
@@ -632,5 +636,5 @@ def demo_mode():
     logger.info("")
 
 
-if __name__ == "__main__":
-    main()
+# if __name__ == "__main__":
+#     main()


### PR DESCRIPTION
- Comment out CLI command interfaces in scribe modules (reserved for future)
- Add 'Coming Soon' notes in README for:
  - Pure CLI-based interface for AI Scribe commands
  - Automated merit tracking and CS point system
- Correct CS terminology from 'CommonShares' to 'Contribution Score'
- Add GitHub issue link for merit tracking feature (#2)
- Update scribe mission.py docstrings to clarify CS definition